### PR TITLE
cloud-init support

### DIFF
--- a/hyperv-ubuntu-160.04-cloud-init.json
+++ b/hyperv-ubuntu-160.04-cloud-init.json
@@ -3,13 +3,13 @@
     "vm_name": "ubuntu-xenial",
     "cpu": "2",
     "ram_size": "2048",
-    "disk_size": "21440",
+    "disk_size": "3072",
     "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
     "iso_checksum_type": "sha1",
     "iso_checksum": "F529548FA7468F2D8413B8427D8E383B830DF5F6",
     "hyperv_switchname": "{{env `hyperv_switchname`}}",
-	"username" : "vagrant",
-	"password" : "vagrant"
+	"username" : "ubuntu",
+	"password" : "ubuntu"
   },
   "builders": [
   {
@@ -39,7 +39,7 @@
       "initrd /install/initrd.gz<enter>",
       "boot<enter>"
     ],
-    "shutdown_command": "echo 'vagrant' | sudo -S -E shutdown -P now",
+    "shutdown_command": "echo 'ubuntu' | sudo -S -E shutdown -P now",
     "ram_size": "{{user `ram_size`}}",
     "cpu": "{{user `cpu`}}",
     "generation": 2,
@@ -48,21 +48,18 @@
   }],
   "provisioners": [{
     "type": "shell",
-    "execute_command": "echo 'vagrant' | sudo -S -E sh {{.Path}}",
+    "execute_command": "echo 'ubuntu' | sudo -S -E sh {{.Path}}",
     "scripts": [
       "./linux/ubuntu/update.sh",
-      "./linux/ubuntu/network.sh",
-      "./linux/common/vagrant.sh",
-      "./linux/common/chef.sh",
-      "./linux/common/motd.sh",
+      "./linux/ubuntu/cloud-init.sh",
       "./linux/ubuntu/cleanup.sh"
     ]
   }],
   "post-processors": [
     {
-      "type": "vagrant",
-      "keep_input_artifact": true,
-      "output": "{{.Provider}}_ubuntu-16.04_chef.box"
+      "type": "compress",
+      "output": "{{.BuildName}}_bundle.zip",
+      "compression_level": 9
     }
   ]
 }

--- a/hyperv-ubuntu-160.04-cloud-init.json
+++ b/hyperv-ubuntu-160.04-cloud-init.json
@@ -1,0 +1,68 @@
+{
+  "variables": {
+    "vm_name": "ubuntu-xenial",
+    "cpu": "2",
+    "ram_size": "2048",
+    "disk_size": "21440",
+    "iso_url": "http://releases.ubuntu.com/16.04/ubuntu-16.04.2-server-amd64.iso",
+    "iso_checksum_type": "sha1",
+    "iso_checksum": "F529548FA7468F2D8413B8427D8E383B830DF5F6",
+    "hyperv_switchname": "{{env `hyperv_switchname`}}",
+	"username" : "vagrant",
+	"password" : "vagrant"
+  },
+  "builders": [
+  {
+    "vm_name":"{{user `vm_name`}}",
+    "type": "hyperv-iso",
+    "disk_size": "{{user `disk_size`}}",
+    "guest_additions_mode":"disable",
+    "iso_url": "{{user `iso_url`}}",
+    "iso_checksum_type": "{{user `iso_checksum_type`}}",
+    "iso_checksum": "{{user `iso_checksum`}}",
+    "communicator":"ssh",
+    "ssh_username": "{{user `username`}}",
+    "ssh_password": "{{user `password`}}",
+    "ssh_timeout" : "4h",
+    "http_directory": "./linux/ubuntu/http/",
+    "boot_wait": "5s",
+    "boot_command": [
+      "<esc><wait10><esc><esc><enter><wait>",
+      "set gfxpayload=1024x768<enter>",
+      "linux /install/vmlinuz ",
+      "preseed/url=http://{{.HTTPIP}}:{{.HTTPPort}}/preseed.cfg ",
+      "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+      "hostname={{.Name}} ",
+      "fb=false debconf/frontend=noninteractive ",
+      "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+      "keyboard-configuration/variant=USA console-setup/ask_detect=false <enter>",
+      "initrd /install/initrd.gz<enter>",
+      "boot<enter>"
+    ],
+    "shutdown_command": "echo 'vagrant' | sudo -S -E shutdown -P now",
+    "ram_size": "{{user `ram_size`}}",
+    "cpu": "{{user `cpu`}}",
+    "generation": 2,
+    "switch_name":"{{user `hyperv_switchname`}}",
+    "enable_secure_boot":false
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "execute_command": "echo 'vagrant' | sudo -S -E sh {{.Path}}",
+    "scripts": [
+      "./linux/ubuntu/update.sh",
+      "./linux/ubuntu/network.sh",
+      "./linux/common/vagrant.sh",
+      "./linux/common/chef.sh",
+      "./linux/common/motd.sh",
+      "./linux/ubuntu/cleanup.sh"
+    ]
+  }],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "keep_input_artifact": true,
+      "output": "{{.Provider}}_ubuntu-16.04_chef.box"
+    }
+  ]
+}

--- a/linux/ubuntu/cloud-init.sh
+++ b/linux/ubuntu/cloud-init.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# install cloud-init
+apt-get -y install cloud-init
+
+#hostname will be managed by cloud-init, but the current value will not be removed
+HOSTNAME=`hostname`
+sed -i "/${HOSTNAME}/d" /etc/hosts

--- a/linux/ubuntu/http/preseed-cloud-init.cfg
+++ b/linux/ubuntu/http/preseed-cloud-init.cfg
@@ -1,0 +1,191 @@
+## Options to set on the command line
+d-i debian-installer/locale string en_US.utf8
+d-i console-setup/ask_detect boolean false
+d-i console-setup/layout string us
+
+d-i netcfg/get_hostname string nl-ams-basebox3
+d-i netcfg/get_domain string unassigned-domain
+
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+d-i clock-setup/utc boolean true
+
+d-i kbd-chooser/method select American English
+
+d-i netcfg/wireless_wep string
+
+d-i base-installer/kernel/override-image string linux-server
+
+d-i debconf debconf/frontend select Noninteractive
+
+d-i pkgsel/install-language-support boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server
+
+### Partitioning
+## Partitioning example
+# If the system has free space you can choose to only partition that space.
+# This is only honoured if partman-auto/method (below) is not set.
+# Alternatives: custom, some_device, some_device_crypto, some_device_lvm.
+#d-i partman-auto/init_automatically_partition select biggest_free
+
+# Alternatively, you may specify a disk to partition. If the system has only
+# one disk the installer will default to using that, but otherwise the device
+# name must be given in traditional, non-devfs format (so e.g. /dev/hda or
+# /dev/sda, and not e.g. /dev/discs/disc0/disc).
+# For example, to use the first SCSI/SATA hard disk:
+#d-i partman-auto/disk string /dev/sda
+# In addition, you'll need to specify the method to use.
+# The presently available methods are:
+# - regular: use the usual partition types for your architecture
+# - lvm:     use LVM to partition the disk
+# - crypto:  use LVM within an encrypted partition
+d-i partman-auto/method string lvm
+
+# If one of the disks that are going to be automatically partitioned
+# contains an old LVM configuration, the user will normally receive a
+# warning. This can be preseeded away...
+d-i partman-lvm/device_remove_lvm boolean true
+# The same applies to pre-existing software RAID array:
+d-i partman-md/device_remove_md boolean true
+# And the same goes for the confirmation to write the lvm partitions.
+d-i partman-lvm/confirm boolean true
+
+# For LVM partitioning, you can select how much of the volume group to use
+# for logical volumes.
+d-i partman-auto-lvm/guided_size string max
+#d-i partman-auto-lvm/guided_size string 10GB
+#d-i partman-auto-lvm/guided_size string 50%
+
+# You can choose one of the three predefined partitioning recipes:
+# - atomic: all files in one partition
+# - home:   separate /home partition
+# - multi:  separate /home, /usr, /var, and /tmp partitions
+d-i partman-auto/choose_recipe select atomic
+
+# Or provide a recipe of your own...
+# If you have a way to get a recipe file into the d-i environment, you can
+# just point at it.
+#d-i partman-auto/expert_recipe_file string /hd-media/recipe
+
+# If not, you can put an entire recipe into the preconfiguration file in one
+# (logical) line. This example creates a small /boot partition, suitable
+# swap, and uses the rest of the space for the root partition:
+#d-i partman-auto/expert_recipe string                         \
+#      boot-root ::                                            \
+#              40 50 100 ext3                                  \
+#                      $primary{ } $bootable{ }                \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ /boot }                     \
+#              .                                               \
+#              500 10000 1000000000 ext3                       \
+#                      method{ format } format{ }              \
+#                      use_filesystem{ } filesystem{ ext3 }    \
+#                      mountpoint{ / }                         \
+#              .                                               \
+#              64 512 300% linux-swap                          \
+#                      method{ swap } format{ }                \
+#              .
+
+# If you just want to change the default filesystem from ext3 to something
+# else, you can do that without providing a full recipe.
+#d-i partman/default_filesystem string ext4
+
+# The full recipe format is documented in the file partman-auto-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository. This also documents how to specify settings such as file
+# system labels, volume group names and which physical devices to include
+# in a volume group.
+
+# This makes partman automatically partition without confirmation, provided
+# that you told it what to do using one of the methods above.
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+## Partitioning using RAID
+# The method should be set to "raid".
+#d-i partman-auto/method string raid
+# Specify the disks to be partitioned. They will all get the same layout,
+# so this will only work if the disks are the same size.
+#d-i partman-auto/disk string /dev/sda /dev/sdb
+
+# Next you need to specify the physical partitions that will be used. 
+#d-i partman-auto/expert_recipe string \
+#      multiraid ::                                         \
+#              1000 5000 4000 raid                          \
+#                      $primary{ } method{ raid }           \
+#              .                                            \
+#              64 512 300% raid                             \
+#                      method{ raid }                       \
+#              .                                            \
+#              500 10000 1000000000 raid                    \
+#                      method{ raid }                       \
+#              .
+
+# Last you need to specify how the previously defined partitions will be
+# used in the RAID setup. Remember to use the correct partition numbers
+# for logical partitions. RAID levels 0, 1, 5, 6 and 10 are supported;
+# devices are separated using "#".
+# Parameters are:
+# <raidtype> <devcount> <sparecount> <fstype> <mountpoint> \
+#          <devices> <sparedevices>
+
+#d-i partman-auto-raid/recipe string \
+#    1 2 0 ext3 /                    \
+#          /dev/sda1#/dev/sdb1       \
+#    .                               \
+#    1 2 0 swap -                    \
+#          /dev/sda5#/dev/sdb5       \
+#    .                               \
+#    0 2 0 ext3 /home                \
+#          /dev/sda6#/dev/sdb6       \
+#    .
+
+# For additional information see the file partman-auto-raid-recipe.txt
+# included in the 'debian-installer' package or available from D-I source
+# repository.
+
+# This makes partman automatically partition without confirmation.
+d-i partman-md/confirm boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+d-i partman-md/confirm_nooverwrite boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+## Controlling how partitions are mounted
+# The default is to mount by UUID, but you can also choose "traditional" to
+# use traditional device names, or "label" to try filesystem labels before
+# falling back to UUIDs.
+#d-i partman/mount_style select uuid
+
+d-i partman-partitioning/no_bootable_gpt_biosgrub boolean false
+d-i partman-partitioning/no_bootable_gpt_efi boolean false
+d-i partman-efi/non_efi_system boolean true
+
+# Default user
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+# Minimum packages (see postinstall.sh)
+d-i pkgsel/include string openssh-server ntp linux-tools-$(uname -r) linux-cloud-tools-$(uname -r) linux-cloud-tools-common
+
+# Upgrade packages after debootstrap? (none, safe-upgrade, full-upgrade)
+# (note: set to none for speed)
+d-i pkgsel/upgrade select none
+
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i finish-install/reboot_in_progress note
+
+d-i pkgsel/update-policy select none
+
+choose-mirror-bin mirror/http/proxy string

--- a/linux/ubuntu/http/preseed-cloud-init.cfg
+++ b/linux/ubuntu/http/preseed-cloud-init.cfg
@@ -39,8 +39,7 @@ tasksel tasksel/first multiselect standard, ubuntu-server
 # - regular: use the usual partition types for your architecture
 # - lvm:     use LVM to partition the disk
 # - crypto:  use LVM within an encrypted partition
-d-i partman-auto/method string lvm
-
+d-i partman-auto/method string regular
 # If one of the disks that are going to be automatically partitioned
 # contains an old LVM configuration, the user will normally receive a
 # warning. This can be preseeded away...
@@ -60,7 +59,7 @@ d-i partman-auto-lvm/guided_size string max
 # - atomic: all files in one partition
 # - home:   separate /home partition
 # - multi:  separate /home, /usr, /var, and /tmp partitions
-d-i partman-auto/choose_recipe select atomic
+#d-i partman-auto/choose_recipe select atomic
 
 # Or provide a recipe of your own...
 # If you have a way to get a recipe file into the d-i environment, you can
@@ -86,10 +85,33 @@ d-i partman-auto/choose_recipe select atomic
 #              64 512 300% linux-swap                          \
 #                      method{ swap } format{ }                \
 #              .
+d-i partman-auto/expert_recipe string                         \
+    efi-root ::                                               \
+            60 70 96                                          \
+                $iflabel{ gpt }                               \
+                $reusemethod{ }                               \
+                method{ efi }                                 \
+                format{ } .                                   \
+                                                              \
+            538 512 1075 ext4                                 \
+                method{ format }                              \
+                format{ }                                     \
+                use_filesystem{ }                             \
+                filesystem{ ext4 }                            \
+                mountpoint{ /boot } .                         \
+                                                              \
+            500 10000 -1 $default_filesystem        \
+                $lvmok{ }                           \
+                method{ format }                    \
+                format{ }                           \
+                use_filesystem{ }                   \
+                $default_filesystem{ }              \
+                mountpoint{ / } .                   \
+
 
 # If you just want to change the default filesystem from ext3 to something
 # else, you can do that without providing a full recipe.
-#d-i partman/default_filesystem string ext4
+d-i partman/default_filesystem string ext4
 
 # The full recipe format is documented in the file partman-auto-recipe.txt
 # included in the 'debian-installer' package or available from D-I source
@@ -103,7 +125,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
-
+d-i partman-basicfilesystems/no_swap boolean false
 ## Partitioning using RAID
 # The method should be set to "raid".
 #d-i partman-auto/method string raid
@@ -163,15 +185,15 @@ d-i partman-lvm/confirm_nooverwrite boolean true
 # falling back to UUIDs.
 #d-i partman/mount_style select uuid
 
-d-i partman-partitioning/no_bootable_gpt_biosgrub boolean false
+d-i partman-partitioning/no_bootable_gpt_biosgrub boolean true
 d-i partman-partitioning/no_bootable_gpt_efi boolean false
-d-i partman-efi/non_efi_system boolean true
+d-i partman-efi/non_efi_system boolean false
 
 # Default user
-d-i passwd/user-fullname string vagrant
-d-i passwd/username string vagrant
-d-i passwd/user-password password vagrant
-d-i passwd/user-password-again password vagrant
+d-i passwd/user-fullname string ubuntu
+d-i passwd/username string ubuntu
+d-i passwd/user-password password ubuntu
+d-i passwd/user-password-again password ubuntu
 d-i user-setup/encrypt-home boolean false
 d-i user-setup/allow-password-weak boolean true
 


### PR DESCRIPTION
Hello,

please review and consider this pull request: 

I have added a template to generate a image that is compatible with cloud-init. The main difference is that I removed the swap partition from preseed.cfg because this will allow cloud-init to resize root partition automatically. cloud-init can also generate a swap file automatically.

Please note that the file hyperv-ubuntu-160.04-cloud-init.json is missing the lines

```
      "./linux/ubuntu/hyperv-xenial.sh",
      "./linux/ubuntu/hyperv-gen2.sh",
```

from my previous pull request, so if you would accept both pull request you this lines have to be added.

Thanks,
Frank
